### PR TITLE
Update dependencies to lingui >= 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ yarn add --dev @babel/core babel-plugin-macros
 yarn add @lingui/react
 ~~~
 
-### 2. Add the following scripts (optional)
+### 2. Add the following scripts
 
 Add these lines to your `package.json` to make your life easier.
 
@@ -371,10 +371,10 @@ and at the same time generate the minified Javascript catalog files, simply run:
 
 ~~~bash
 # NPM
-npm run sync   # alias of `npm run extract --overwrite && npm run compile`
+npm run sync
 
 # Yarn
-yarn sync      # alias of `yarn extract --overwrite && yarn compile`
+yarn sync
 ~~~
 
 ### Sync and Purge
@@ -384,10 +384,10 @@ the current branch as reference, use the `--clean` option.
 
 ~~~bash
 # NPM
-npm run sync_and_purge   # alias of `npm run extract --overwrite --clean && npm run compile`
+npm run sync_and_purge
 
 # Yarn
-yarn sync_and_purge      # alias of `yarn extract --overwrite --clean && yarn compile`
+yarn sync_and_purge
 ~~~
 
 As the name says, this operation will also perform a sync at the same time.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translation/lingui",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Translation.io client for Lingui (React & JavaScript)",
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@lingui/cli": "^3.11",
-    "@lingui/macro": "^3.11",
-    "@lingui/react": "^3.11",
+    "@lingui/cli": ">=4.0",
+    "@lingui/macro": ">=4.0",
+    "@lingui/react": ">=4.0",
     "@babel/core": ">=7.0",
-    "babel-plugin-macros": ">=2.0"
+    "babel-plugin-macros": ">=3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@lingui/cli": ">=4.0",
-    "@lingui/macro": ">=4.0",
-    "@lingui/react": ">=4.0",
+    "@lingui/cli": "^4",
+    "@lingui/macro": "^4",
+    "@lingui/react": "^4",
     "@babel/core": ">=7.0",
     "babel-plugin-macros": ">=3.0"
   }


### PR DESCRIPTION
I have updated the `package.json` file to require Lingui dependencies equal or greater than v 4.0.
I have also updated the README file to remove aliases in comments after the "sync" commands.

Quickly tested on a React project, it works.