### PR TITLE
Update to Lingui v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v4.0.0](https://github.com/translation/lingui/releases/tag/v4.0.0) (2026-xx-xx)
+
+#### New features:
+
+ * Compability with [Lingui V6](https://lingui.dev/blog/2026/04/22/announcing-lingui-6.0).
+ * **Migration:** refer to the [migration guide from Lingui 5.x to 6.x](https://lingui.dev/releases/migration-6).
+
+#### Breaking change:
+
+ * **Config file**: the `format` parameter no longer accepts a string value, so you should:
+   - remove this parameter (default format is **PO**)
+   - or use a [formatter function](https://lingui.dev/ref/conf#format) in your `lingui.config.{js|ts}` file (not possible in a `.linguirc` file)
+
 ## [v3.0.0](https://github.com/translation/lingui/releases/tag/v3.0.0) (2025-01-27)
 
 #### New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v4.0.0](https://github.com/translation/lingui/releases/tag/v4.0.0) (2026-xx-xx)
+## [v4.0.0](https://github.com/translation/lingui/releases/tag/v4.0.0) (2026-05-04)
 
 #### New features:
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ You can refer directly to the [Lingui documentation](https://lingui.dev/) for mo
 
 ----------
 
+**Versions:**
+
  * To use Lingui **v6**, you need to install  `@translation/lingui` **v 4.0.0** (latest)
- * To use Lingui **v5**, you need to install  `@translation/lingui` **v 3.0.0** (https://www.npmjs.com/package/@translation/lingui/v/3.0.0)
+ * To use Lingui **v5**, you need to install [`@translation/lingui` **v 3.0.0**](https://www.npmjs.com/package/@translation/lingui/v/3.0.0)
  * To use Lingui **v4**, you need to install [`@translation/lingui` **v 2.0.0**](https://www.npmjs.com/package/@translation/lingui/v/2.0.0)
 
 ----------
@@ -327,13 +329,16 @@ The configuration file looks like this:
     "path": "src/locales/{locale}/messages",
     "include": ["src"]
   }],
-  "format": "po",
   "service": {
     "name": "TranslationIO",
     "apiKey": "abcdefghijklmnopqrstuvwxyz012345"
   }
 }
 ~~~
+
+**Notes:**
+- With older Lingui versions (< 6.0), you must add the parameter `"format": "po"`
+- For a fine-tuned config, use a `lingui.config.js` file instead of `.linguirc` (see [Lingui Configuration](https://lingui.dev/ref/conf))
 
 ### 5. Setup your application
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ the [Lingui](https://github.com/lingui/js-lingui) i18n framework.
 to simplify the installation of [Lingui](https://github.com/lingui/js-lingui).
 You can refer directly to the [Lingui documentation](https://lingui.dev/) for more advanced Lingui features.
 
-**Versions of this meta-package:**
+----------
 
- * For Lingui **v6**, install  `@translation/lingui` (v4.0.0 - latest)
+ * For Lingui **v6**, install  `@translation/lingui`
  * For Lingui **v5**, install [`@translation/lingui@3.0.0`](https://www.npmjs.com/package/@translation/lingui/v/3.0.0)
  * For Lingui **v4**, install [`@translation/lingui@2.0.0`](https://www.npmjs.com/package/@translation/lingui/v/2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,15 @@ Write only the source text, and keep it synchronized with your translators on
 * The [Translation.io](https://translation.io/lingui) client is directly integrated into
 the [Lingui](https://github.com/lingui/js-lingui) i18n framework.
 
-* This repository provides additional documentation and a useful meta-package
+* This repository provides additional documentation and a useful **meta-package**
 to simplify the installation of [Lingui](https://github.com/lingui/js-lingui).
 You can refer directly to the [Lingui documentation](https://lingui.dev/) for more advanced Lingui features.
 
-----------
+**Versions of this meta-package:**
 
-**Versions:**
-
- * To use Lingui **v6**, you need to install  `@translation/lingui` **v 4.0.0** (latest)
- * To use Lingui **v5**, you need to install [`@translation/lingui` **v 3.0.0**](https://www.npmjs.com/package/@translation/lingui/v/3.0.0)
- * To use Lingui **v4**, you need to install [`@translation/lingui` **v 2.0.0**](https://www.npmjs.com/package/@translation/lingui/v/2.0.0)
+ * For Lingui **v6**, install  `@translation/lingui` (v4.0.0 - latest)
+ * For Lingui **v5**, install [`@translation/lingui@3.0.0`](https://www.npmjs.com/package/@translation/lingui/v/3.0.0)
+ * For Lingui **v4**, install [`@translation/lingui@2.0.0`](https://www.npmjs.com/package/@translation/lingui/v/2.0.0)
 
 ----------
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ You can refer directly to the [Lingui documentation](https://lingui.dev/) for mo
 
 ----------
 
- * To use Lingui **v5**, you need to install  `@translation/lingui` **v 3.0.0** (latest)
+ * To use Lingui **v6**, you need to install  `@translation/lingui` **v 4.0.0** (latest)
+ * To use Lingui **v5**, you need to install  `@translation/lingui` **v 3.0.0** (https://www.npmjs.com/package/@translation/lingui/v/3.0.0)
  * To use Lingui **v4**, you need to install [`@translation/lingui` **v 2.0.0**](https://www.npmjs.com/package/@translation/lingui/v/2.0.0)
 
 ----------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translation/lingui",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Translation.io client for Lingui (React & JavaScript)",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@lingui/cli": "^5",
-    "@lingui/babel-plugin-lingui-macro": "^5",
-    "@lingui/react": "^5"
+    "@lingui/cli": "^6",
+    "@lingui/babel-plugin-lingui-macro": "^6",
+    "@lingui/react": "^6"
   }
 }


### PR DESCRIPTION
This PR bumps the Lingui dependencies to `^6` and updates the README and CHANGELOG files.

The **breaking change** for us is that the `"format": "po"` parameter is not accepted in the `.linguirc` config file anymore. 

PO is the default format, and for specific formatter options, it is recommended to use a `lingui.config.js` (or `.ts`) with an instance of a formatter, not a string saying "po". The `.linguirc` file is pure JSON, and it's OK for us to suggest using it for simplicity, but it may become deprecated in future versions.

## TODO after merge

* Update the CHANGELOG file again on master with the **current date** for the release of our meta-package
* Releasing `@translation/lingui` v4 package to npmjs.com